### PR TITLE
build: warning remove

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,8 +7,8 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface AudioPlayer {
+        "playerTitle": string;
         "src": string;
-        "title": string;
     }
 }
 declare global {
@@ -24,8 +24,8 @@ declare global {
 }
 declare namespace LocalJSX {
     interface AudioPlayer {
+        "playerTitle"?: string;
         "src"?: string;
-        "title"?: string;
     }
     interface IntrinsicElements {
         "audio-player": AudioPlayer;

--- a/src/components/audio-player/audio-player.tsx
+++ b/src/components/audio-player/audio-player.tsx
@@ -8,7 +8,7 @@ import { Component, h, Prop, State, Watch, getAssetPath } from '@stencil/core';
 })
 export class AudioPlayer {
 
-  @Prop() title: string;
+  @Prop() playerTitle: string;
   @Prop() src: string;
 
   @State() isPlaying: boolean = false;
@@ -51,7 +51,7 @@ export class AudioPlayer {
   render() {
     return (
       <div class="container">
-        <div class="title">{this.title}</div>
+        <div class="title">{this.playerTitle}</div>
         <div class="player">
           <div class="play-button" onClick={this.togglePlay}>
             {

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,7 +2,6 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   namespace: 'stencil-accordion',
-  enableCache: false,
   outputTargets: [
     {
       type: 'dist',

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,6 +2,7 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   namespace: 'stencil-accordion',
+  enableCache: false,
   outputTargets: [
     {
       type: 'dist',


### PR DESCRIPTION
Removes build warning:

> [ WARN  ]  Build Warn: ./src/components/audio-player/audio-player.tsx:11:11
 The @Prop() name "title" is a reserved public name. Please rename the "title" prop so it does not conflict
 with an existing standardized prototype member. Reusing prop names that are already defined on the element's
 prototype may cause unexpected runtime errors or user-interface issues on various browsers, so it's best to
 avoid them entirely.

by changing:
```jsx
@Prop() title: string;
```
to:
```jsx
@Prop() playerTitle: string;
```