### PR TITLE
build: added `Config` option - `enableCache: false`

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,6 +2,7 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   namespace: 'stencil-accordion',
+  enableCache: false,
   outputTargets: [
     {
       type: 'dist',


### PR DESCRIPTION
Added Config option `enableCache: false` so there is no need to re-run `npm run start` when changing `<button>` to `<div>`; specifically when changing this:
```tsx
<button class="play-button" onClick={this.togglePlay}>
  {
    this.isPlaying
      ? <img src={getAssetPath("../../assets/pause.svg")} />
      : <img src={getAssetPath("../../assets/play.svg")} />
  }
</button>
```
to this:
```tsx
<div class="play-button" onClick={this.togglePlay}>
  {
    this.isPlaying
      ? <img src={getAssetPath("../../assets/pause.svg")} />
      : <img src={getAssetPath("../../assets/play.svg")} />
  }
</div>
```

When merged,
>For the change to appear, we have to run npm run start again.

sentence could be removed from the tutorial. 